### PR TITLE
Fixes #5 - JaCoCo coverage is wrongly retrieved

### DIFF
--- a/src/reports/jacoco.js
+++ b/src/reports/jacoco.js
@@ -21,9 +21,9 @@ export async function getReports(root) {
     core.info(`Load JaCoCo report '${f}'`);
     const contents = await fs.readFile(f, { encoding: 'utf8' });
     const missedMatches = contents
-      .match(/(?<=<counter[^>]+type="LINE"[^>]+missed=")[0-9.]+(?=")/);
+      .match(/(?<=<counter[^>]+type="LINE"[^>]+missed=")[0-9.]+(?=")/g);
     const coveredMatches = contents
-      .match(/(?<=<counter[^>]+type="LINE"[^>]+covered=")[0-9.]+(?=")/);
+      .match(/(?<=<counter[^>]+type="LINE"[^>]+covered=")[0-9.]+(?=")/g);
     if (!missedMatches?.length || !coveredMatches?.length) {
       core.info('Report is not a valid JaCoCo report');
       continue; // Invalid report file, trying the next one

--- a/test/data/jacoco/jacoco.xml
+++ b/test/data/jacoco/jacoco.xml
@@ -1,6 +1,28 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?><!DOCTYPE report PUBLIC
     "-//JACOCO//DTD Report 1.1//EN" "report.dtd">
 <report name="Test">
+    <sessioninfo id="sessionId" start="1732456096354" dump="1732456102329"/>
+    <package name="com/foo/bar/">
+      <class name="com/foo/bar/Baz" sourcefilename="Baz.java">
+        <method name="&lt;init&gt;" desc="()V" line="12">
+          <counter type="INSTRUCTION" missed="0" covered="4"/>
+          <counter type="LINE" missed="0" covered="2"/>
+          <counter type="COMPLEXITY" missed="0" covered="1"/>
+          <counter type="METHOD" missed="0" covered="1"/>
+        </method>
+        <method name="method1" desc="()Ljava/lang/Integer;" line="23">
+          <counter type="INSTRUCTION" missed="3" covered="0"/>
+          <counter type="LINE" missed="1" covered="0"/>
+          <counter type="COMPLEXITY" missed="1" covered="0"/>
+          <counter type="METHOD" missed="1" covered="0"/>
+        </method>
+        <counter type="INSTRUCTION" missed="12" covered="4"/>
+        <counter type="LINE" missed="4" covered="2"/>
+        <counter type="COMPLEXITY" missed="4" covered="1"/>
+        <counter type="METHOD" missed="4" covered="1"/>
+        <counter type="CLASS" missed="0" covered="1"/>
+      </class>
+    </package>
     <counter type="INSTRUCTION" missed="2170" covered="3853"/>
     <counter type="BRANCH" missed="150" covered="150"/>
     <counter type="LINE" missed="521" covered="994"/>


### PR DESCRIPTION
Made the regex global to retrieve all the matches instead of the first one only.
Also modified the test resource file to be more ressemblant to a real one.